### PR TITLE
Add card shuffling and visual verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,5 +10,6 @@ Cartes Mission est un petit jeu web de glisser-déposer. L'objectif est de place
 ## Comment jouer
 
 - Faites glisser chaque carte vers un emplacement vide pour reconstituer la chronologie.
-- Le bouton **Vérifier l'ordre** devient actif une fois toutes les cartes placées. Cliquez‑le pour savoir si la suite est correcte.
+- Les cartes sont mélangées au début de chaque partie.
+- Le bouton **Vérifier l'ordre** devient actif une fois toutes les cartes placées. Lors de la vérification, chaque carte s'affiche en vert si elle est bien placée et en rouge sinon.
 - Vous pouvez réarranger les cartes tant que le compte‑à‑rebours n'est pas terminé.

--- a/script.js
+++ b/script.js
@@ -1,5 +1,17 @@
 const cards = document.querySelectorAll('.card');
 const slots = document.querySelectorAll('.slot');
+
+function shuffleCards() {
+  const container = document.querySelector('.cards');
+  const array = Array.from(container.children);
+  for (let i = array.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [array[i], array[j]] = [array[j], array[i]];
+  }
+  array.forEach(card => container.appendChild(card));
+}
+
+shuffleCards();
 let dragged = null;
 
 cards.forEach(card => {
@@ -9,6 +21,7 @@ cards.forEach(card => {
     if (parent && parent.classList.contains('slot')) {
       parent.classList.remove('filled');
     }
+    card.classList.remove('correct', 'incorrect');
     dragged = card;
     setTimeout(() => card.style.opacity = '0.5', 0);
   });
@@ -35,12 +48,21 @@ function checkAllFilled() {
 }
 
 document.getElementById('checkBtn').addEventListener('click', () => {
-  const placed = Array.from(slots).map(slot => parseInt(slot.firstChild.dataset.order));
-  const correct = placed.every((val, idx, arr) => idx === 0 || arr[idx - 1] <= val);
-  if (correct) {
-    alert('Bravo ! L\'ordre est correct.');
+  cards.forEach(card => card.classList.remove('correct', 'incorrect'));
+  let allCorrect = true;
+  slots.forEach((slot, idx) => {
+    const card = slot.firstChild;
+    if (parseInt(card.dataset.order) === idx + 1) {
+      card.classList.add('correct');
+    } else {
+      card.classList.add('incorrect');
+      allCorrect = false;
+    }
+  });
+  if (allCorrect) {
+    alert("Bravo ! L'ordre est correct.");
   } else {
-    alert('L\'ordre est incorrect, veuillez réessayer.');
+    alert("L'ordre est incorrect, veuillez réessayer.");
   }
 });
 

--- a/style.css
+++ b/style.css
@@ -39,6 +39,14 @@ h1 {
   background: #fff;
   border-style: solid;
 }
+
+.card.correct {
+  background: #c8e6c9;
+}
+
+.card.incorrect {
+  background: #ffcdd2;
+}
 button {
   display: block;
   margin: 0 auto;


### PR DESCRIPTION
## Summary
- shuffle the cards when each game loads
- color cards green if correct or red if wrong when verifying order
- document the shuffling and color highlights

## Testing
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_684ea0d3dde8832685c4493823bd2d31