### PR TITLE
Add card validation feedback

### DIFF
--- a/script.js
+++ b/script.js
@@ -7,8 +7,9 @@ cards.forEach(card => {
     // remove filled class from previous slot if dragging from one
     const parent = card.parentElement;
     if (parent && parent.classList.contains('slot')) {
-      parent.classList.remove('filled');
+      parent.classList.remove('filled', 'correct', 'incorrect');
     }
+    card.classList.remove('correct', 'incorrect');
     dragged = card;
     setTimeout(() => card.style.opacity = '0.5', 0);
   });
@@ -35,9 +36,24 @@ function checkAllFilled() {
 }
 
 document.getElementById('checkBtn').addEventListener('click', () => {
-  const placed = Array.from(slots).map(slot => parseInt(slot.firstChild.dataset.order));
-  const correct = placed.every((val, idx, arr) => idx === 0 || arr[idx - 1] <= val);
-  if (correct) {
+  let success = true;
+  slots.forEach(slot => {
+    const card = slot.firstElementChild;
+    if (!card) {
+      success = false;
+      return;
+    }
+    card.classList.remove('correct', 'incorrect');
+    slot.classList.remove('correct', 'incorrect');
+    if (card.dataset.order === slot.dataset.index) {
+      card.classList.add('correct');
+    } else {
+      card.classList.add('incorrect');
+      success = false;
+    }
+  });
+
+  if (success) {
     alert('Bravo ! L\'ordre est correct.');
   } else {
     alert('L\'ordre est incorrect, veuillez réessayer.');

--- a/style.css
+++ b/style.css
@@ -59,3 +59,13 @@ button:disabled {
   text-align: center;
   margin: 10px 0;
 }
+
+.card.correct {
+  border-color: #28a745;
+  background: #e6ffe6;
+}
+
+.card.incorrect {
+  border-color: #dc3545;
+  background: #ffe6e6;
+}


### PR DESCRIPTION
## Summary
- highlight correctly and incorrectly placed cards
- remove state styling when dragging cards
- check each slot for card order on verification

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684ea0d58894832687dca07ff54c8b1b