### PR TITLE
Shuffle cards before attaching listeners

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,5 +1,12 @@
-const cards = document.querySelectorAll('.card');
+const cardsContainer = document.querySelector('.cards');
 const slots = document.querySelectorAll('.slot');
+
+// Shuffle cards before adding listeners
+const shuffled = Array.from(cardsContainer.children)
+  .sort(() => Math.random() - 0.5);
+shuffled.forEach(card => cardsContainer.appendChild(card));
+
+const cards = cardsContainer.querySelectorAll('.card');
 let dragged = null;
 
 cards.forEach(card => {


### PR DESCRIPTION
## Summary
- randomize card order before starting the game
- ensure event listeners attach to the shuffled cards

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684ea0d5ded48326885bb7dbbcca432c